### PR TITLE
adding definition for description field

### DIFF
--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -181,6 +181,10 @@
           "solar_illumination": {
             "title": "Solar Illumination",
             "type": "number"
+          },
+          "description": {
+            "title": "Detailed Band Description",
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
## Proposed Change

Add field definition for `description` to circumvent the divergence between the `schema.json` and `README.md` files.

Addresses #16

- Adds the following to field definition:
```json
"description": {
   "title": "Detailed Band Description",
   "type": "string"
}
```