### PR TITLE
Don't error when bands is used only in collections at the top-level

### DIFF
--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -150,6 +150,9 @@
         ],
         "anyOf": [
           {
+            "$ref": "#/definitions/require_in_bands"
+          },
+          {
             "$ref": "#/definitions/require_assets"
           },
           {


### PR DESCRIPTION
A collection that lists the bands at the collection top-level should be valid.